### PR TITLE
Add a couple niche messages, prettify things a bit

### DIFF
--- a/Showdown.NET/Definitions/StatusID.cs
+++ b/Showdown.NET/Definitions/StatusID.cs
@@ -1,0 +1,13 @@
+﻿namespace Showdown.NET.Definitions;
+
+public enum StatusID
+{
+    None,
+    Fnt,
+    Brn,
+    Frz,
+    Par,
+    Psn,
+    Tox,
+    Slp,
+}

--- a/Showdown.NET/Protocol/Elements.cs
+++ b/Showdown.NET/Protocol/Elements.cs
@@ -411,6 +411,29 @@ public sealed record BlockElement(string Pokemon, string Effect, string? Move, s
 }
 
 /// <summary>
+///     A move has failed due to their being no target Pokémon <see cref="Pokemon"/>. <see cref="Pokemon"/> is <see langword="null"/> in Generation 1.
+///     This action is specific to Generations 1-4 as in later Generations a failed move will display using <see cref="FailElement"/>.
+/// </summary>
+[PublicAPI]
+[MinorAction]
+public sealed record NoTargetElement(string? Pokemon) : ProtocolElement
+{
+    public static NoTargetElement Parse(string[] segments, out int usedCount)
+    {
+        string? pokemon = null;
+        usedCount = 0;
+
+        if (segments.Length > 1)
+        {
+            pokemon = segments[1];
+            usedCount = 1;
+        }
+
+        return new NoTargetElement(pokemon);
+    }
+}
+
+/// <summary>
 ///     The move used by the <see cref="Source" /> Pokémon missed (maybe absent) the <see cref="Target" /> Pokémon.
 /// </summary>
 [PublicAPI]

--- a/Showdown.NET/Protocol/Elements.cs
+++ b/Showdown.NET/Protocol/Elements.cs
@@ -98,7 +98,7 @@ public sealed record GenElement(int GenNum) : ProtocolElement
 ///     Will be sent if the game is official in some way.
 ///     <list type="bullet">
 ///         <item>
-///             If <see cref="Message"/> is <see langword="null"/>, the game will affect the player's ladder rating (Elo score).
+///             If <see cref="Message" /> is <see langword="null" />, the game will affect the player's ladder rating (Elo score).
 ///         </item>
 ///         <item>
 ///             Otherwise, indicates an official game that is not actually rated, such as being a tournament game.
@@ -293,7 +293,7 @@ public struct MoveDetails(bool miss, bool still, string? anim)
 ///         as a fraction; if it is your own Pokémon
 ///         then it will be <c>CURRENT/MAX</c>, if not, it will be <c>/100</c> if HP Percentage Mod is in effect and
 ///         <c>/48</c> otherwise.
-///         <see cref="Status" /> can be left <see cref="StatusID.None" />, or it can be <see cref="StatusID.Slp"/>, <see cref="StatusID.Par"/>, etc.
+///         <see cref="Status" /> can be left <see cref="StatusID.None" />, or it can be <see cref="StatusID.Slp" />, <see cref="StatusID.Par" />, etc.
 ///     </para>
 /// </summary>
 /// <remarks>
@@ -411,8 +411,8 @@ public sealed record BlockElement(string Pokemon, string Effect, string? Move, s
 }
 
 /// <summary>
-///     A move has failed due to their being no target Pokémon <see cref="Pokemon"/>. <see cref="Pokemon"/> is <see langword="null"/> in Generation 1.
-///     This action is specific to Generations 1-4 as in later Generations a failed move will display using <see cref="FailElement"/>.
+///     A move has failed due to their being no target Pokémon <see cref="Pokemon" />. <see cref="Pokemon" /> is <see langword="null" /> in Generation 1.
+///     This action is specific to Generations 1-4 as in later Generations a failed move will display using <see cref="FailElement" />.
 /// </summary>
 [PublicAPI]
 [MinorAction]

--- a/Showdown.NET/Protocol/Elements.cs
+++ b/Showdown.NET/Protocol/Elements.cs
@@ -97,11 +97,53 @@ public sealed record GenElement(int GenNum) : ProtocolElement
 }
 
 /// <summary>
-///     The name of the format being played. (see also <see cref="Definitions.FormatID" />).
+///     Will be sent if the game is official in some way.
+///     <list type="bullet">
+///         <item>
+///             If <see cref="Message"/> is <see langword="null"/>, the game will affect the player's ladder rating (Elo score).
+///         </item>
+///         <item>
+///             Otherwise, indicates an official game that is not actually rated, such as being a tournament game.
+///         </item>
+///     </list>
+/// </summary>
+[PublicAPI]
+public sealed record RatedElement(string? Message) : ProtocolElement
+{
+    public static RatedElement Parse(string[] segments, out int usedCount)
+    {
+        string? message = null;
+        usedCount = 0;
+
+        if (segments.Length > 1)
+        {
+            message = segments[1];
+            usedCount = 1;
+        }
+
+        return new RatedElement(message);
+    }
+}
+
+/// <summary>
+///     The name of the format being played. (see also <see cref="FormatID" />).
 /// </summary>
 /// <param name="FormatName"></param>
 [PublicAPI]
 public sealed record TierElement(string FormatName) : ProtocolElement;
+
+/// <summary>
+///     Will appear multiple times, one for each rule.
+/// </summary>
+[PublicAPI]
+public sealed record RuleElement(string Rule, string Description) : ProtocolElement
+{
+    public static RuleElement Parse(string[] segments)
+    {
+        var parts = segments[1].Split(':', 2, StringSplitOptions.TrimEntries);
+        return new RuleElement(parts[0], parts[1]);
+    }
+}
 
 /// <summary>
 ///     Marks the start of Team Preview.
@@ -164,6 +206,24 @@ public sealed record StartElement : ProtocolElement;
 /// </summary>
 [PublicAPI]
 public sealed record WinElement(string Username) : ProtocolElement;
+
+/// <summary>
+///     The battle has ended in a tie.
+/// </summary>
+[PublicAPI]
+public sealed record TieElement : ProtocolElement;
+
+/// <summary>
+///     A message related to the battle timer has been sent. The official client displays these messages in red.
+///     <see cref="InactiveElement" /> means that the timer is on at the time the message was sent,
+///     while <see cref="InactiveOffElement" /> means that the timer is off.
+/// </summary>
+[PublicAPI]
+public sealed record InactiveElement(string Message) : ProtocolElement;
+
+/// <inheritdoc cref="InactiveElement" />
+[PublicAPI]
+public sealed record InactiveOffElement(string Message) : ProtocolElement;
 
 /// <summary>
 ///     <para>

--- a/Showdown.NET/Protocol/ProtocolCodec.cs
+++ b/Showdown.NET/Protocol/ProtocolCodec.cs
@@ -310,11 +310,11 @@ public static class ProtocolCodec
                 elem = MissElement.Parse(segments, out usedCount);
                 break;
             case "-damage" when segments.Length > 2:
-                elem = DamageElement.Parse(segments[1], segments[2]);
+                elem = DamageElement.Parse(segments[1], segments[2], heal: false);
                 usedCount = 2;
                 break;
             case "-heal" when segments.Length > 2:
-                elem = HealElement.Parse(segments[1], segments[2]);
+                elem = DamageElement.Parse(segments[1], segments[2], heal: true);
                 usedCount = 2;
                 break;
             case "-sethp" when segments.Length > 2:
@@ -322,11 +322,11 @@ public static class ProtocolCodec
                 usedCount = 2;
                 break;
             case "-status" when segments.Length > 2:
-                elem = new StatusElement(segments[1], segments[2]);
+                elem = StatusElement.Parse(segments, cure: false);
                 usedCount = 2;
                 break;
             case "-curestatus" when segments.Length > 2:
-                elem = new CureStatusElement(segments[1], segments[2]);
+                elem = StatusElement.Parse(segments, cure: true);
                 usedCount = 2;
                 break;
             case "-cureteam" when segments.Length > 1:
@@ -334,23 +334,19 @@ public static class ProtocolCodec
                 usedCount = 1;
                 break;
             case "-boost" when segments.Length > 3:
-                var (stat, amount) = BoostElement.ParseBoost(segments);
-                elem = new BoostElement(segments[1], stat, amount);
+                elem = BoostElement.Parse(segments, boost: true);
                 usedCount = 3;
                 break;
             case "-unboost" when segments.Length > 3:
-                (stat, amount) = BoostElement.ParseBoost(segments);
-                elem = new UnboostElement(segments[1], stat, amount);
+                elem = BoostElement.Parse(segments, boost: false);
                 usedCount = 3;
                 break;
             case "-setboost" when segments.Length > 3:
-                (stat, amount) = BoostElement.ParseBoost(segments);
-                elem = new SetBoostElement(segments[1], stat, amount);
+                elem = BoostElement.Parse(segments, boost: null);
                 usedCount = 3;
                 break;
             case "-swapboost" when segments.Length > 3:
-                var stats = SwapBoostElement.ParseSwapBoost(segments);
-                elem = new SwapBoostElement(segments[1], segments[2], stats);
+                elem = SwapBoostElement.Parse(segments);
                 usedCount = 3;
                 break;
             case "-invertboost" when segments.Length > 1:

--- a/Showdown.NET/Protocol/ProtocolCodec.cs
+++ b/Showdown.NET/Protocol/ProtocolCodec.cs
@@ -303,6 +303,9 @@ public static class ProtocolCodec
             case "-block" when segments.Length > 2:
                 elem = BlockElement.Parse(segments, out usedCount);
                 break;
+            case "-notarget":
+                elem = NoTargetElement.Parse(segments, out usedCount);
+                break;
             case "-miss" when segments.Length > 1:
                 elem = MissElement.Parse(segments, out usedCount);
                 break;

--- a/Showdown.NET/Protocol/ProtocolCodec.cs
+++ b/Showdown.NET/Protocol/ProtocolCodec.cs
@@ -198,6 +198,12 @@ public static class ProtocolCodec
                 elem = new TierElement(segments[1]);
                 usedCount = 1;
                 break;
+            case "rated":
+                elem = RatedElement.Parse(segments, out usedCount);
+                break;
+            case "rule":
+                elem = RuleElement.Parse(segments);
+                break;
             case "clearpoke":
                 elem = new ClearPokeElement();
                 break;
@@ -220,6 +226,14 @@ public static class ProtocolCodec
                 elem = new RequestElement(segments[1]);
                 usedCount = 1;
                 break;
+            case "inactive" when segments.Length > 1:
+                elem = new InactiveElement(segments[1]);
+                usedCount = 1;
+                break;
+            case "inactiveoff" when segments.Length > 1:
+                elem = new InactiveOffElement(segments[1]);
+                usedCount = 1;
+                break;
             case "upkeep":
                 elem = new UpkeepElement();
                 break;
@@ -230,6 +244,9 @@ public static class ProtocolCodec
             case "win" when segments.Length > 1:
                 elem = new WinElement(segments[1]);
                 usedCount = 1;
+                break;
+            case "tie":
+                elem = new TieElement();
                 break;
             case "t:" when segments.Length > 1:
                 elem = TimestampElement.Parse(segments[1]);


### PR DESCRIPTION
Add the elements: `Rated`, `Rule`, `Tie`, `Inactive`, `InactiveOff`, and `NoTarget`.
Change uses of `string?` for non-volatile status effects to `StatusID`.
Change some repeated `Parse()` methods in favor of providing a parameter in a single `Parse` method that changes the final returned element. (for example, `DamageElement.Parse()` and `HealElement.Parse()` are unified into `DamageElement.Parse()`, which is given a `heal` parameter.) 