### PR TITLE
Add IPokemonArgs interface

### DIFF
--- a/Showdown.NET/Protocol/Elements.cs
+++ b/Showdown.NET/Protocol/Elements.cs
@@ -231,7 +231,7 @@ public sealed record InactiveOffElement(string Message) : ProtocolElement;
 ///     <see cref="Details" /> contains secondary information.
 /// </summary>
 [PublicAPI]
-public sealed record MoveElement(string Pokemon, string Move, string Target, MoveDetails Details) : ProtocolElement
+public sealed record MoveElement(string Pokemon, string Move, string Target, MoveDetails Details) : ProtocolElement, IPokemonArgs
 {
     public static MoveElement Parse(string[] segments)
     {
@@ -301,7 +301,7 @@ public struct MoveDetails(bool miss, bool still, string? anim)
 ///     which indicates it was unintentional (forced by Whirlwind, Roar, etc).
 /// </remarks>
 [PublicAPI]
-public sealed record SwitchElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement
+public sealed record SwitchElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs
 {
     public static (string hp, StatusID status) ParseHPStatus(string hpStatus)
     {
@@ -314,7 +314,7 @@ public sealed record SwitchElement(string Pokemon, string Details, string HP, St
 
 /// <inheritdoc cref="SwitchElement" />
 [PublicAPI]
-public sealed record DragElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement;
+public sealed record DragElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     <para>
@@ -326,12 +326,12 @@ public sealed record DragElement(string Pokemon, string Details, string HP, Stat
 ///     Syntax is the same as <see cref="SwitchElement" />.
 /// </summary>
 [PublicAPI]
-public sealed record DetailsChangeElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement;
+public sealed record DetailsChangeElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs;
 
 /// <inheritdoc cref="DetailsChangeElement" />
 [PublicAPI]
 [MinorAction]
-public sealed record FormeChangeElement(string Pokemon, string Species, string HP, StatusID Status) : ProtocolElement;
+public sealed record FormeChangeElement(string Pokemon, string Species, string HP, StatusID Status) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     <para>
@@ -341,13 +341,13 @@ public sealed record FormeChangeElement(string Pokemon, string Species, string H
 ///     <see cref="Pokemon" /> will be the NEW Pokémon ID - i.e. it will have the nickname of the Zoroark (or other Illusion user).
 /// </summary>
 [PublicAPI]
-public sealed record ReplaceElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement;
+public sealed record ReplaceElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Moves already active <see cref="Pokemon" /> to active field <see cref="Position" /> where the leftmost position is 0 and each position to the right counts up by 1.
 /// </summary>
 [PublicAPI]
-public sealed record SwapElement(string Pokemon, int Position) : ProtocolElement
+public sealed record SwapElement(string Pokemon, int Position) : ProtocolElement, IPokemonArgs
 {
     public static SwapElement Parse(string[] segments)
         => new(segments[1], int.Parse(segments[2]));
@@ -359,7 +359,7 @@ public sealed record SwapElement(string Pokemon, int Position) : ProtocolElement
 ///     (such as paralysis, Disable, etc). Sometimes, the move it was trying to use is given.
 /// </summary>
 [PublicAPI]
-public sealed record CantElement(string Pokemon, string Reason, string? Move) : ProtocolElement
+public sealed record CantElement(string Pokemon, string Reason, string? Move) : ProtocolElement, IPokemonArgs
 {
     public static CantElement Parse(string[] segments, out int usedCount)
     {
@@ -377,7 +377,7 @@ public sealed record CantElement(string Pokemon, string Reason, string? Move) : 
 ///     The Pokémon <see cref="Pokemon" /> has fainted.
 /// </summary>
 [PublicAPI]
-public sealed record FaintElement(string Pokemon) : ProtocolElement;
+public sealed record FaintElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The specified <see cref="Action" /> has failed against the <see cref="Pokemon" /> targeted. The
@@ -386,7 +386,7 @@ public sealed record FaintElement(string Pokemon) : ProtocolElement;
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record FailElement(string Pokemon, string Action) : ProtocolElement;
+public sealed record FailElement(string Pokemon, string Action) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     An effect targeted at <see cref="Pokemon" /> was blocked by <see cref="Effect" />. This may optionally specify that
@@ -395,7 +395,7 @@ public sealed record FailElement(string Pokemon, string Action) : ProtocolElemen
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record BlockElement(string Pokemon, string Effect, string? Move, string? Attacker) : ProtocolElement
+public sealed record BlockElement(string Pokemon, string Effect, string? Move, string? Attacker) : ProtocolElement, IPokemonArgs
 {
     public static BlockElement Parse(string[] segments, out int usedCount)
     {
@@ -416,7 +416,7 @@ public sealed record BlockElement(string Pokemon, string Effect, string? Move, s
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record NoTargetElement(string? Pokemon) : ProtocolElement
+public sealed record NoTargetElement(string? Pokemon) : ProtocolElement, IPokemonArgs
 {
     public static NoTargetElement Parse(string[] segments, out int usedCount)
     {
@@ -438,7 +438,7 @@ public sealed record NoTargetElement(string? Pokemon) : ProtocolElement
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record MissElement(string Source, string? Target) : ProtocolElement
+public sealed record MissElement(string Source, string? Target) : ProtocolElement, IPokemonArgs
 {
     public static MissElement Parse(string[] segments, out int usedCount)
     {
@@ -466,7 +466,7 @@ public sealed record MissElement(string Source, string? Target) : ProtocolElemen
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record DamageElement(string Pokemon, string HP, StatusID Status) : ProtocolElement
+public sealed record DamageElement(string Pokemon, string HP, StatusID Status) : ProtocolElement, IPokemonArgs
 {
     public static ProtocolElement Parse(string pokemon, string hpStatus, bool heal)
     {
@@ -484,21 +484,21 @@ public sealed record DamageElement(string Pokemon, string HP, StatusID Status) :
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record HealElement(string Pokemon, string HP, StatusID Status) : ProtocolElement;
+public sealed record HealElement(string Pokemon, string HP, StatusID Status) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The specified Pokémon <see cref="Pokemon" /> now has <see cref="HP" /> hit points.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record SetHPElement(string Pokemon, string HP) : ProtocolElement;
+public sealed record SetHPElement(string Pokemon, string HP) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The Pokémon <see cref="Pokemon" /> has been inflicted with <see cref="Status" />.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record StatusElement(string Pokemon, StatusID Status) : ProtocolElement
+public sealed record StatusElement(string Pokemon, StatusID Status) : ProtocolElement, IPokemonArgs
 {
     public static ProtocolElement Parse(string[] segments, bool cure)
     {
@@ -514,21 +514,21 @@ public sealed record StatusElement(string Pokemon, StatusID Status) : ProtocolEl
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record CureStatusElement(string Pokemon, StatusID Status) : ProtocolElement;
+public sealed record CureStatusElement(string Pokemon, StatusID Status) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The Pokémon <see cref="Pokemon" /> has used a move that cures its team of status effects, like Heal Bell.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record CureTeamElement(string Pokemon) : ProtocolElement;
+public sealed record CureTeamElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The specified Pokémon <see cref="Pokemon" /> has gained <see cref="Amount" /> in <see cref="Stat" />, using the standard rules for Pokémon stat changes in-battle.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record BoostElement(string Pokemon, StatID Stat, int Amount) : ProtocolElement
+public sealed record BoostElement(string Pokemon, StatID Stat, int Amount) : ProtocolElement, IPokemonArgs
 {
     public static ProtocolElement Parse(string[] segments, bool? boost)
     {
@@ -551,7 +551,7 @@ public sealed record BoostElement(string Pokemon, StatID Stat, int Amount) : Pro
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record UnboostElement(string Pokemon, StatID Stat, int Amount) : ProtocolElement;
+public sealed record UnboostElement(string Pokemon, StatID Stat, int Amount) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Same as <see cref="BoostElement" /> and <see cref="UnboostElement" />, but <see cref="Stat" /> is set to <see cref="Amount" /> instead of boosted by <see cref="Amount" />.
@@ -559,7 +559,7 @@ public sealed record UnboostElement(string Pokemon, StatID Stat, int Amount) : P
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record SetBoostElement(string Pokemon, StatID Stat, int Amount) : ProtocolElement;
+public sealed record SetBoostElement(string Pokemon, StatID Stat, int Amount) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Swaps the boosts from <see cref="Stats" /> between the <see cref="Source" /> Pokémon and <see cref="Target" /> Pokémon.
@@ -567,7 +567,7 @@ public sealed record SetBoostElement(string Pokemon, StatID Stat, int Amount) : 
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record SwapBoostElement(string Source, string Target, StatID[] Stats) : ProtocolElement
+public sealed record SwapBoostElement(string Source, string Target, StatID[] Stats) : ProtocolElement, IPokemonArgs
 {
     public static SwapBoostElement Parse(string[] segments)
     {
@@ -587,7 +587,7 @@ public sealed record SwapBoostElement(string Source, string Target, StatID[] Sta
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record InvertBoostElement(string Pokemon) : ProtocolElement;
+public sealed record InvertBoostElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Clears all of the boosts of the target <see cref="Pokemon" />.
@@ -595,7 +595,7 @@ public sealed record InvertBoostElement(string Pokemon) : ProtocolElement;
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record ClearBoostElement(string Pokemon) : ProtocolElement;
+public sealed record ClearBoostElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Clears all boosts from all Pokémon on both sides.
@@ -611,7 +611,7 @@ public sealed record ClearAllBoostElement : ProtocolElement;
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record ClearPositiveBoostElement(string Target, string Pokemon, string Effect) : ProtocolElement;
+public sealed record ClearPositiveBoostElement(string Target, string Pokemon, string Effect) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Clear the negative boosts from the target Pokémon <see cref="Pokemon" />.
@@ -619,7 +619,7 @@ public sealed record ClearPositiveBoostElement(string Target, string Pokemon, st
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record ClearNegativeBoostElement(string Pokemon) : ProtocolElement;
+public sealed record ClearNegativeBoostElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Copy the boosts from <see cref="Source" /> Pokémon to <see cref="Target" /> Pokémon
@@ -627,7 +627,7 @@ public sealed record ClearNegativeBoostElement(string Pokemon) : ProtocolElement
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record CopyBoostElement(string Source, string Target) : ProtocolElement;
+public sealed record CopyBoostElement(string Source, string Target) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Indicates the weather that is currently in effect.
@@ -707,42 +707,42 @@ public sealed record SwapSideConditionsElement : ProtocolElement;
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record StartVolatileElement(string Pokemon, string Effect) : ProtocolElement;
+public sealed record StartVolatileElement(string Pokemon, string Effect) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The volatile status from <see cref="Effect" /> inflicted on the <see cref="Pokemon" /> Pokémon has ended.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record EndVolatileElement(string Pokemon, string Effect) : ProtocolElement;
+public sealed record EndVolatileElement(string Pokemon, string Effect) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     A move has dealt a critical hit against the <see cref="Pokemon" />.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record CritElement(string Pokemon) : ProtocolElement;
+public sealed record CritElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     A move was super effective against the <see cref="Pokemon" />.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record SuperEffectiveElement(string Pokemon) : ProtocolElement;
+public sealed record SuperEffectiveElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     A move was not very effective against the <see cref="Pokemon" />.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record ResistedElement(string Pokemon) : ProtocolElement;
+public sealed record ResistedElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The <see cref="Pokemon" /> was immune to a move.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record ImmuneElement(string Pokemon) : ProtocolElement;
+public sealed record ImmuneElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The <see cref="Item" /> held by the <see cref="Pokemon" /> has been changed or revealed.
@@ -751,7 +751,7 @@ public sealed record ImmuneElement(string Pokemon) : ProtocolElement;
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record ItemElement(string Pokemon, string Item) : ProtocolElement;
+public sealed record ItemElement(string Pokemon, string Item) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     <para>
@@ -765,7 +765,7 @@ public sealed record ItemElement(string Pokemon, string Item) : ProtocolElement;
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record EndItemElement(string Pokemon, string Item) : ProtocolElement;
+public sealed record EndItemElement(string Pokemon, string Item) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The <see cref="Ability" /> of the <see cref="Pokemon" /> has been changed or revealed.
@@ -774,56 +774,56 @@ public sealed record EndItemElement(string Pokemon, string Item) : ProtocolEleme
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record AbilityElement(string Pokemon, string Ability) : ProtocolElement;
+public sealed record AbilityElement(string Pokemon, string Ability) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The <see cref="Pokemon" /> has had its ability suppressed by Gastro Acid.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record EndAbilityElement(string Pokemon) : ProtocolElement;
+public sealed record EndAbilityElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The Pokémon <see cref="Pokemon" /> has transformed into SPECIES by the move Transform or the ability Imposter.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record TransformElement(string Pokemon, string Species) : ProtocolElement;
+public sealed record TransformElement(string Pokemon, string Species) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The Pokémon <see cref="Pokemon" /> used MEGASTONE to Mega Evolve.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record MegaElement(string Pokemon, string Megastone) : ProtocolElement;
+public sealed record MegaElement(string Pokemon, string Megastone) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The Pokémon <see cref="Pokemon" /> has reverted to its primal forme.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record PrimalElement(string Pokemon) : ProtocolElement;
+public sealed record PrimalElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The Pokémon <see cref="Pokemon" /> has used ITEM to Ultra Burst into SPECIES.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record BurstElement(string Pokemon, string Species, string Item) : ProtocolElement;
+public sealed record BurstElement(string Pokemon, string Species, string Item) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The Pokémon <see cref="Pokemon" /> has used the z-move version of its move.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record ZPowerElement(string Pokemon) : ProtocolElement;
+public sealed record ZPowerElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     A z-move has broken through protect and hit the <see cref="Pokemon" />.
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record ZBrokenElement(string Pokemon) : ProtocolElement;
+public sealed record ZBrokenElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     <para>
@@ -838,7 +838,7 @@ public sealed record ZBrokenElement(string Pokemon) : ProtocolElement;
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record ActivateElement(string Pokemon, string Effect) : ProtocolElement;
+public sealed record ActivateElement(string Pokemon, string Effect) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Displays a message in parentheses to the client. Hint messages appear to explain
@@ -879,7 +879,7 @@ public sealed record CombineElement : ProtocolElement;
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record WaitingElement(string Source, string Target) : ProtocolElement;
+public sealed record WaitingElement(string Source, string Target) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     <para>
@@ -889,7 +889,7 @@ public sealed record WaitingElement(string Source, string Target) : ProtocolElem
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record PrepareElement(string Attacker, string Move, string? Defender) : ProtocolElement
+public sealed record PrepareElement(string Attacker, string Move, string? Defender) : ProtocolElement, IPokemonArgs
 {
     public static PrepareElement Parse(string[] segments, out int usedCount)
     {
@@ -909,7 +909,7 @@ public sealed record PrepareElement(string Attacker, string Move, string? Defend
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record MustRechargeElement(string Pokemon) : ProtocolElement;
+public sealed record MustRechargeElement(string Pokemon) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     <b>DEPRECATED:</b> A move did absolutely nothing. (For example: Splash).
@@ -924,7 +924,7 @@ public sealed record NothingElement : ProtocolElement;
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record HitCountElement(string Pokemon, int Num) : ProtocolElement
+public sealed record HitCountElement(string Pokemon, int Num) : ProtocolElement, IPokemonArgs
 {
     public static HitCountElement Parse(string pokemon, string num)
     {
@@ -938,7 +938,7 @@ public sealed record HitCountElement(string Pokemon, int Num) : ProtocolElement
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record SingleMoveElement(string Pokemon, string Move) : ProtocolElement;
+public sealed record SingleMoveElement(string Pokemon, string Move) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     The Pokémon <see cref="Pokemon" /> used move <see cref="Move" /> which causes a temporary effect lasting the duration of the turn.
@@ -946,7 +946,7 @@ public sealed record SingleMoveElement(string Pokemon, string Move) : ProtocolEl
 /// </summary>
 [PublicAPI]
 [MinorAction]
-public sealed record SingleTurnElement(string Pokemon, string Move) : ProtocolElement;
+public sealed record SingleTurnElement(string Pokemon, string Move) : ProtocolElement, IPokemonArgs;
 
 /// <summary>
 ///     Signals the upkeep phase of the turn where the number of turns left for field conditions are updated.
@@ -1075,3 +1075,12 @@ public enum ErrorType
 /// </summary>
 [PublicAPI]
 public sealed record UnknownElement(string Content) : ProtocolElement;
+
+public interface IPokemonArgs
+{
+    string? Pokemon => null;
+    string? Source => null;
+    string? Target => null;
+    string? Attacker => null;
+    string? Defender => null;
+}

--- a/Showdown.NET/Protocol/Elements.cs
+++ b/Showdown.NET/Protocol/Elements.cs
@@ -411,7 +411,7 @@ public sealed record BlockElement(string Pokemon, string Effect, string? Move, s
 }
 
 /// <summary>
-///     A move has failed due to their being no target Pokémon <see cref="Pokemon" />. <see cref="Pokemon" /> is <see langword="null" /> in Generation 1.
+///     A move has failed due to there being no target Pokémon <see cref="Pokemon" />. <see cref="Pokemon" /> is <see langword="null" /> in Generation 1.
 ///     This action is specific to Generations 1-4 as in later Generations a failed move will display using <see cref="FailElement" />.
 /// </summary>
 [PublicAPI]

--- a/Showdown.NET/Protocol/Elements.cs
+++ b/Showdown.NET/Protocol/Elements.cs
@@ -165,7 +165,7 @@ public sealed record ClearPokeElement : ProtocolElement;
 ///     Note that forme and shininess are hidden on this, unlike on the <see cref="SwitchElement" /> details message.
 /// </summary>
 [PublicAPI]
-public sealed record PokeElement(int Player, string Details, string Item) : ProtocolElement;
+public sealed record PokeElement(int Player, string Details, string Item) : ProtocolElement, IDetailsArg;
 
 /// <summary>
 ///     These messages appear if you're playing a format that uses team previews.
@@ -301,7 +301,7 @@ public struct MoveDetails(bool miss, bool still, string? anim)
 ///     which indicates it was unintentional (forced by Whirlwind, Roar, etc).
 /// </remarks>
 [PublicAPI]
-public sealed record SwitchElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs
+public sealed record SwitchElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs, IDetailsArg
 {
     public static (string hp, StatusID status) ParseHPStatus(string hpStatus)
     {
@@ -314,7 +314,7 @@ public sealed record SwitchElement(string Pokemon, string Details, string HP, St
 
 /// <inheritdoc cref="SwitchElement" />
 [PublicAPI]
-public sealed record DragElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs;
+public sealed record DragElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs, IDetailsArg;
 
 /// <summary>
 ///     <para>
@@ -326,7 +326,7 @@ public sealed record DragElement(string Pokemon, string Details, string HP, Stat
 ///     Syntax is the same as <see cref="SwitchElement" />.
 /// </summary>
 [PublicAPI]
-public sealed record DetailsChangeElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs;
+public sealed record DetailsChangeElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs, IDetailsArg;
 
 /// <inheritdoc cref="DetailsChangeElement" />
 [PublicAPI]
@@ -341,7 +341,7 @@ public sealed record FormeChangeElement(string Pokemon, string Species, string H
 ///     <see cref="Pokemon" /> will be the NEW Pokémon ID - i.e. it will have the nickname of the Zoroark (or other Illusion user).
 /// </summary>
 [PublicAPI]
-public sealed record ReplaceElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs;
+public sealed record ReplaceElement(string Pokemon, string Details, string HP, StatusID Status) : ProtocolElement, IPokemonArgs, IDetailsArg;
 
 /// <summary>
 ///     Moves already active <see cref="Pokemon" /> to active field <see cref="Position" /> where the leftmost position is 0 and each position to the right counts up by 1.
@@ -1083,4 +1083,9 @@ public interface IPokemonArgs
     string? Target => null;
     string? Attacker => null;
     string? Defender => null;
+}
+
+public interface IDetailsArg
+{
+    string Details { get; }
 }


### PR DESCRIPTION
adds interface allowing users to easily see if a given message has pokemon arguments (generic Pokemon, then giver-receiver with Source/Target and Attacker/Defender)